### PR TITLE
Adds in Sophronia Broadcasting as a Company

### DIFF
--- a/corporations.md
+++ b/corporations.md
@@ -51,3 +51,6 @@ Produces fitness equipment, such as skateboards, weight machines and clothing.
 
 # Robust Industries, LLC
 Produces consumables, including snacks, drinks and cigarettes.
+
+# Sophronia Broadcasting
+A Broadcasting Company. Behind 'Sophronia Broadcasting's Plasteel Chef', and 'Sophronia Broadcasting's History Comes Alive'. Also creates merchandise in the form of the ingredient beacon and hero beacon.

--- a/corporations.md
+++ b/corporations.md
@@ -53,4 +53,4 @@ Produces fitness equipment, such as skateboards, weight machines and clothing.
 Produces consumables, including snacks, drinks and cigarettes.
 
 # Sophronia Broadcasting
-A Broadcasting Company. Behind 'Sophronia Broadcasting's Plasteel Chef', and 'Sophronia Broadcasting's History Comes Alive'. Also creates merchandise in the form of the ingredient beacon and hero beacon.
+A Broadcasting Company. Behind 'Sophronia Broadcasting's Plasteel Chef', and 'Sophronia Broadcasting's History Comes Alive'. Also creates merchandise in the form of the Cook's Ingredient Beacon and Curator's Hero Beacon. The Company is believed by some to conduct mind control experiments on their viewers.


### PR DESCRIPTION
Sophronia Broadcasting is referenced by the Ingredient Beacon given to the Cook with, "Please enjoy your Sophronia Broadcasting's 'Plasteel Chef' Ingredients Box, exactly as shown in the hit show!", as well as the Curators Hero Beacon with, "Please enjoy your Sophronia Broadcasting's 'History Comes Alive branded' Costume Set, exactly as shown in the hit show!". I think it'd be a sensible addition, and adds nicely to any any reporter crewmembers, or a reporter AI who don't know what company they should say they work for. The original idea behind the company was that they were involved in mind control experiments, but it wasn't referenced in the game so I didn't add it.